### PR TITLE
Add generic producer option and add workaround to AvroProducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 This producer simulates location updates (latitude and longitude) from a moving bus.
 
+The producer used in the image is `producer.py`, which uses `AvroProducer`. It contains a workaround in order to be compatible with KSQL: it sends the bus_id in the value as well as setting it as the key. 
+
+An alternative producer is `producer_key_str.py`, which uses a generic `Producer`, and encodes the key as string, and value as Avro.
+
 If you want to modify the `producer.py` file and test out your changes in a venice pipeline, you can run `docker build --tag YOUR_IMAGE_NAME.` in this repo, then use `image: YOUR_IMAGE_NAME` in your `docker-compose.yml` file.
 
 If you are making many changes and you want docker-compose to build your image every time you run `docker-compose up --build`, you can use `build: PATH_TO_THIS_REPO` in your `docker-compose.yml` file.

--- a/admin_api.py
+++ b/admin_api.py
@@ -23,8 +23,7 @@ class CustomAdmin:
   
       new_topics = [NewTopic(topic_name,
                              num_partitions=3,
-                             replication_factor=3,
-                             request_required_acks=1)
+                             replication_factor=3)
                     for topic_name in topic_names]
       # Call create_topics to asynchronously create topics, a dict
       # of <topic,future> is returned.

--- a/producer.py
+++ b/producer.py
@@ -25,7 +25,11 @@ You must set the TOPIC_NAME environment variable.
 This image does not have a default TOPIC_NAME set, to avoid
 potentially confusing errors.
 
-Reference: https://github.com/confluentinc/confluent-kafka-python
+References:
+https://github.com/confluentinc/confluent-kafka-python
+https://github.com/confluentinc/confluent-kafka-python/issues/428#issuecomment-444320103
+https://docs.confluent.io/current/clients/confluent-kafka-python/
+
 """
 
 BROKER = os.environ['BROKER']
@@ -72,17 +76,9 @@ value_schema = avro.loads("""
 # Initialize producer
 # Configuration options:
 # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-print(help(Producer))
 producer = Producer(
     {
         'bootstrap.servers': BROKER,
-        # Maximum number of messages to send at once.
-        # Limits the size of your queue.
-        # The default is 10000 at the time of this writing.
-        # See above link for updated defaults.
-        # It is set to 1 here so the user can see the output
-        # update per message in the logs.
-        'batch.num.messages': 1,
         'default.topic.config': {'acks': 1}
     }
 )
@@ -113,7 +109,7 @@ for i in range(n):
         print("Local producer queue is full: {} messages in queue".format(
           len(producer)))
 
-    print("I just produced key: {} lat: {}, lng: {}".format(key, lat, lng))
+    print("EVENT COUNT: {} key: {} lat: {}, lng: {}".format(i, key, lat, lng))
     # Polls the producer for events and calls the corresponding callbacks
     # (if registered)
     #
@@ -123,6 +119,6 @@ for i in range(n):
     # likely not serve the delivery callback for the last produce()d message.
     lat += 0.000001
     lng += 0.000001
-    producer.poll(timeout=3)
+    producer.poll(timeout=0)
 # Cleanup step: wait for all messages to be delivered before exiting.
 producer.flush()

--- a/producer.py
+++ b/producer.py
@@ -1,4 +1,4 @@
-from confluent_kafka import Producer
+from confluent_kafka import avro, Producer
 from confluent_kafka.avro import CachedSchemaRegistryClient
 from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
 
@@ -32,6 +32,7 @@ BROKER = os.environ['BROKER']
 SCHEMA_REGISTRY_URL = os.environ['SCHEMA_REGISTRY_URL']
 TOPIC_NAME = os.environ['TOPIC_NAME']
 
+
 def delivery_callback(err, msg):
     """
     Called once for each message produced to indicate delivery result.
@@ -41,20 +42,22 @@ def delivery_callback(err, msg):
         print('Message delivery failed: {}'.format(err))
     else:
         print('Message delivered to {} [{}]'.
-        format(msg.topic(), msg.partition()))
+              format(msg.topic(), msg.partition()))
+
 
 # Create a topic if it doesn't exist yet
+print('Checking if topic: {} exists...'.format(TOPIC_NAME))
 admin = CustomAdmin(BROKER)
 if not admin.topic_exists(TOPIC_NAME):
-  admin.create_topics([TOPIC_NAME])
+    admin.create_topics([TOPIC_NAME])
 
 # Define wrapper function for serializing in avro format
 serialize_avro = MessageSerializer(
     CachedSchemaRegistryClient(SCHEMA_REGISTRY_URL)
-  ).encode_record_with_schema
+).encode_record_with_schema
 
 # Define value schema
-value_schema = """
+value_schema = avro.loads("""
     {
         "namespace": "septa.bus.location",
         "name": "value",
@@ -64,20 +67,24 @@ value_schema = """
             {"name": "lng", "type": "float", "doc": "longitude"}
         ]
     }
-"""
+""")
 
 # Initialize producer
 # Configuration options:
 # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+print(help(Producer))
 producer = Producer(
-  {
-    'bootstrap.servers': BROKER,
-    # Maximum number of messages to send at once. Limits the size of your
-    # queue. The default is 10000 at the time of this writing (see above link
-    # for updated config). It is set to 1 here so the user can see the output
-    # update per message in the logs.
-    'batch_num_messages': 1,
-  }
+    {
+        'bootstrap.servers': BROKER,
+        # Maximum number of messages to send at once.
+        # Limits the size of your queue.
+        # The default is 10000 at the time of this writing.
+        # See above link for updated defaults.
+        # It is set to 1 here so the user can see the output
+        # update per message in the logs.
+        'batch.num.messages': 1,
+        'default.topic.config': {'acks': 1}
+    }
 )
 
 # Initialize key and values
@@ -88,34 +95,34 @@ lng = -75.18071
 # Produce n events simulating bus movements
 n = 10000
 for i in range(n):
-  value = {
-    "lat": lat,
-    "lng": lng 
-  }
-  serialized_value = serialize_avro(topic=TOPIC_NAME,
-                                    value_schema=value_schema,
-                                    value=value,
-                                    is_key=false)
-  serialized_key = str(key)
-  try:
-    producer.produce(topic=TOPIC_NAME,
-                     value=serialized_value,
-                     key=serialized_key,
-                     callback=delivery_callback)
-  except BufferError:
-    print("Local producer queue is full: {} messages in queue".format(len(producer)))
+    value = {
+        "lat": lat,
+        "lng": lng
+    }
+    serialized_value = serialize_avro(topic=TOPIC_NAME,
+                                      schema=value_schema,
+                                      record=value,
+                                      is_key=False)
+    serialized_key = str(key)
+    try:
+        producer.produce(topic=TOPIC_NAME,
+                         value=serialized_value,
+                         key=serialized_key,
+                         callback=delivery_callback)
+    except BufferError:
+        print("Local producer queue is full: {} messages in queue".format(
+          len(producer)))
 
-  print("I just produced key: {} lat: {}, lng: {}".format(key, lat, lng))
-  # Polls the producer for events and calls the corresponding callbacks
-  # (if registered)
-  #
-  # `timeout` refers to the maximum time to block waiting for events
-  #
-  # Since produce() is an asynchronous API this poll() call will most
-  # likely not serve the delivery callback for the last produce()d message.
-  lat += 0.000001
-  lng += 0.000001
-  producer.poll(timeout=0)
-  time.sleep(1)
-# Cleanup step: wait for all messages to be delivered before exiting. 
+    print("I just produced key: {} lat: {}, lng: {}".format(key, lat, lng))
+    # Polls the producer for events and calls the corresponding callbacks
+    # (if registered)
+    #
+    # `timeout` refers to the maximum time to block waiting for events
+    #
+    # Since produce() is an asynchronous API this poll() call will most
+    # likely not serve the delivery callback for the last produce()d message.
+    lat += 0.000001
+    lng += 0.000001
+    producer.poll(timeout=3)
+# Cleanup step: wait for all messages to be delivered before exiting.
 producer.flush()

--- a/producer.py
+++ b/producer.py
@@ -21,6 +21,7 @@ The latitude and longitude are changes by a constant value
 with every event.
 
 You must set the TOPIC_NAME environment variable.
+
 This image does not have a default TOPIC_NAME set, to avoid
 potentially confusing errors.
 
@@ -33,6 +34,7 @@ BROKER = os.environ['BROKER']
 SCHEMA_REGISTRY_URL = os.environ['SCHEMA_REGISTRY_URL']
 TOPIC_NAME = os.environ['TOPIC_NAME']
 
+
 def delivery_report(err, msg):
     """
     Called once for each message produced to indicate delivery result.
@@ -42,13 +44,13 @@ def delivery_report(err, msg):
         print('Message delivery failed: {}'.format(err))
     else:
         print('Message delivered to {} [{}]'.
-        format(msg.topic(), msg.partition()))
+              format(msg.topic(), msg.partition()))
 
 
 # Create a topic if it doesn't exist yet
 admin = CustomAdmin(BROKER)
 if not admin.topic_exists(TOPIC_NAME):
-  admin.create_topics([TOPIC_NAME])
+    admin.create_topics([TOPIC_NAME])
 
 # Define schemas
 # NOTE: bus_id is included in the value as a hacky workaround
@@ -85,13 +87,13 @@ key_schema = avro.loads("""
 
 # Initialize producer
 avroProducer = AvroProducer(
-  {
-    'bootstrap.servers': BROKER,
-    'on_delivery': delivery_report,
-    'schema.registry.url': SCHEMA_REGISTRY_URL
-  },
-  default_key_schema=key_schema,
-  default_value_schema=value_schema
+    {
+        'bootstrap.servers': BROKER,
+        'on_delivery': delivery_report,
+        'schema.registry.url': SCHEMA_REGISTRY_URL
+    },
+    default_key_schema=key_schema,
+    default_value_schema=value_schema
 )
 
 # Initialize key and values
@@ -105,9 +107,9 @@ key = {"bus_id": 1}
 count = 1
 while True:
     value = {
-      "bus_id": bus_id,
-      "lat": lat,
-      "lng": lng 
+        "bus_id": bus_id,
+        "lat": lat,
+        "lng": lng
     }
     avroProducer.produce(topic=TOPIC_NAME, value=value, key=key)
     print("EVENT COUNT: {} key: {} lat: {}, lng: {}".format(count, key, lat, lng))
@@ -118,11 +120,11 @@ while True:
     #
     # Since produce() is an asynchronous API this poll() call will most
     # likely not serve the delivery callback for the last produce()d message.
-    producer.poll(timeout=0)
+    avroProducer.poll(timeout=0)
     time.sleep(0.3)
 
     lat += 0.000001
     lng += 0.000001
     count += 1
 # Cleanup step: wait for all messages to be delivered before exiting.
-producer.flush()
+avroProducer.flush()

--- a/producer_key_str.py
+++ b/producer_key_str.py
@@ -1,5 +1,6 @@
-from confluent_kafka import avro
-from confluent_kafka.avro import AvroProducer
+from confluent_kafka import avro, Producer
+from confluent_kafka.avro import CachedSchemaRegistryClient
+from confluent_kafka.avro.serializer.message_serializer import MessageSerializer
 
 import os
 import requests
@@ -24,16 +25,25 @@ You must set the TOPIC_NAME environment variable.
 This image does not have a default TOPIC_NAME set, to avoid
 potentially confusing errors.
 
-This version of the producer serializes the key with avro.
+This version of the producer serializes the key as a string and
+the values in avro format, because ksql requires the key to be a string.
 
-For a version that serializes the key as a string, see the repo.
+For a version that serializes the key and values as avro,
+see `producer_key_avro.py` 
+
+References:
+https://github.com/confluentinc/confluent-kafka-python
+https://github.com/confluentinc/confluent-kafka-python/issues/428#issuecomment-444320103
+https://docs.confluent.io/current/clients/confluent-kafka-python/
+
 """
 
 BROKER = os.environ['BROKER']
 SCHEMA_REGISTRY_URL = os.environ['SCHEMA_REGISTRY_URL']
 TOPIC_NAME = os.environ['TOPIC_NAME']
 
-def delivery_report(err, msg):
+
+def delivery_callback(err, msg):
     """
     Called once for each message produced to indicate delivery result.
     Triggered by poll() or flush().
@@ -42,74 +52,68 @@ def delivery_report(err, msg):
         print('Message delivery failed: {}'.format(err))
     else:
         print('Message delivered to {} [{}]'.
-        format(msg.topic(), msg.partition()))
+              format(msg.topic(), msg.partition()))
 
 
 # Create a topic if it doesn't exist yet
 admin = CustomAdmin(BROKER)
 if not admin.topic_exists(TOPIC_NAME):
-  admin.create_topics([TOPIC_NAME])
+    admin.create_topics([TOPIC_NAME])
 
-# Define schemas
-# NOTE: bus_id is included in the value as a hacky workaround
-# because ksql does not recognize avro-encoded keys and
-# AvroProducer does not allow a different encoding for keys at the
-# time of this writing.
-# See https://github.com/confluentinc/confluent-kafka-python/issues/428
+# Define wrapper function for serializing in avro format
+serialize_avro = MessageSerializer(
+    CachedSchemaRegistryClient(SCHEMA_REGISTRY_URL)
+).encode_record_with_schema
+
+# Define value schema
 value_schema = avro.loads("""
     {
         "namespace": "septa.bus.location",
         "name": "value",
         "type": "record",
         "fields": [
-            {"name": "bus_id", "type": "int", "doc": "bus id"},
             {"name": "lat", "type": "float", "doc": "latitude"},
             {"name": "lng", "type": "float", "doc": "longitude"}
         ]
     }
 """)
 
-key_schema = avro.loads("""
-{
-   "namespace": "septa.bus.location",
-   "name": "key",
-   "type": "record",
-   "fields" : [
-     {
-       "name" : "bus_id",
-       "type" : "int"
-     }
-   ]
-}
-""")
-
 # Initialize producer
-avroProducer = AvroProducer(
-  {
-    'bootstrap.servers': BROKER,
-    'on_delivery': delivery_report,
-    'schema.registry.url': SCHEMA_REGISTRY_URL
-  },
-  default_key_schema=key_schema,
-  default_value_schema=value_schema
+# Configuration options:
+# https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+producer = Producer(
+    {
+        'bootstrap.servers': BROKER,
+        'default.topic.config': {'acks': 1}
+    }
 )
 
 # Initialize key and values
+key = 1
 lat = 40.043152
 lng = -75.18071
-bus_id = 1
 
-key = {"bus_id": 1}
-
-# Produce events simulating bus movements, forever
+# Produce events simulating bus movements
 count = 1
 while True:
     value = {
-      "bus_id": bus_id,
-      "lat": lat,
-      "lng": lng 
+        "lat": lat,
+        "lng": lng
     }
-    avroProducer.produce(topic=TOPIC_NAME, value=value, key=key)
+    serialized_value = serialize_avro(topic=TOPIC_NAME,
+                                      schema=value_schema,
+                                      record=value,
+                                      is_key=False)
+    serialized_key = str(key)
+    try:
+        producer.produce(topic=TOPIC_NAME,
+                         value=serialized_value,
+                         key=serialized_key,
+                         callback=delivery_callback)
+    except BufferError:
+        print("Local producer queue is full: {} messages in queue".format(
+          len(producer)))
+
     print("EVENT COUNT: {} key: {} lat: {}, lng: {}".format(count, key, lat, lng))
     # Polls the producer for events and calls the corresponding callbacks
     # (if registered)


### PR DESCRIPTION
I implemented a producer that sends the key as a string and the value as Avro.
This works with ksql but does NOT work with the connector that moves data to postgresql.
The original AvroProducer worked with postgresql but NOT with ksql.

What to do?
Looks like the only way to work with both, for now, is to do send the key as Avro AND send the bus_id in the value, like David did before.

I also made the code compliant with pep8 (python style guide).